### PR TITLE
remove field implements

### DIFF
--- a/src/ResourceTrait.php
+++ b/src/ResourceTrait.php
@@ -75,16 +75,7 @@ trait ResourceTrait
                 $this->link($name, $value);
             }
         }
-    }
-
-    /**
-     * @return array
-     */
-    public function fields()
-    {
-        $fields = array_keys(\Yii::getObjectVars($this));
-        return array_combine($fields, $fields);
-    }
+    }    
 
     /**
      * @return array


### PR DESCRIPTION
Active Record uses `fields()` by default and it expected when work by API.
Your implement return always `[]` attributes.