### PR TITLE
If server posts no relationship data, then error occurs

### DIFF
--- a/src/actions/CreateAction.php
+++ b/src/actions/CreateAction.php
@@ -47,7 +47,7 @@ class CreateAction extends Action
         $request = Yii::$app->getRequest();
         $model->load($request->getBodyParams());
         if ($model->save()) {
-            $this->linkRelationships($model, $request->getBodyParam('relationships'));
+            $this->linkRelationships($model, $request->getBodyParam('relationships', []));
             $response = Yii::$app->getResponse();
             $response->setStatusCode(201);
             $id = implode(',', array_values($model->getPrimaryKey(true)));

--- a/src/actions/UpdateAction.php
+++ b/src/actions/UpdateAction.php
@@ -39,7 +39,7 @@ class UpdateAction extends Action
             throw new ServerErrorHttpException('Failed to update the object for unknown reason.');
         }
 
-        $this->linkRelationships($model, $request->getBodyParam('relationships'));
+        $this->linkRelationships($model, $request->getBodyParam('relationships', []));
 
         return $model;
     }


### PR DESCRIPTION
TypeError: Argument 2 passed to tuyakhov\jsonapi\actions\Action::linkRelationships() must be of the type array, null given, called in 
/yii2/vendor/tuyakhov/yii2-json-api/src/actions/UpdateAction.php on line 42