### PR TITLE
Pass in relationship name in addition to the query

### DIFF
--- a/src/actions/ViewRelatedAction.php
+++ b/src/actions/ViewRelatedAction.php
@@ -45,7 +45,7 @@ class ViewRelatedAction extends Action
         }
 
         if ($this->prepareDataProvider !== null) {
-            return call_user_func($this->prepareDataProvider, $this, $related);
+            return call_user_func($this->prepareDataProvider, $this, $related, $name);
         }
 
         if ($related->multiple) {


### PR DESCRIPTION
@tuyakhov Happy to send in a test for this if you'd like, but would be useful to pass the relationship name on down to the data provider as well ...