### PR TITLE
fixed pagination

### DIFF
--- a/src/actions/IndexAction.php
+++ b/src/actions/IndexAction.php
@@ -100,7 +100,7 @@ class IndexAction extends Action
             'class' => ActiveDataProvider::className(),
             'query' => $query,
             'pagination' => [
-                'params' => Yii::$app->getRequest()->getQueryParam('page', []),
+                'params' => ["page" => Yii::$app->getRequest()->getQueryParam('page', [])],
                 'pageSizeParam' => 'size'
             ],
             'sort' => [

--- a/src/actions/IndexAction.php
+++ b/src/actions/IndexAction.php
@@ -100,7 +100,6 @@ class IndexAction extends Action
             'class' => ActiveDataProvider::className(),
             'query' => $query,
             'pagination' => [
-                'params' => ["page" => Yii::$app->getRequest()->getQueryParam('page', [])],
                 'pageSizeParam' => 'size'
             ],
             'sort' => [

--- a/tests/actions/IndexActionTest.php
+++ b/tests/actions/IndexActionTest.php
@@ -41,6 +41,19 @@ class IndexActionTest extends TestCase
         $this->assertSame(['field1' => SORT_ASC, 'field2' => SORT_DESC], $dataProvider->getSort()->orders);
     }
 
+    public function testPageTwo()
+    {
+        $action = new IndexAction('test', new Controller('test', \Yii::$app), [
+            'modelClass' => ResourceModel::className()
+        ]);
+        $page = [
+            "page" => 2,
+        ];
+        \Yii::$app->getRequest()->setQueryParams($page);
+        $this->assertInstanceOf(ActiveDataProvider::className(), $dataProvider = $action->run());
+        $this->assertSame($page, $dataProvider->getPagination()->params);
+    }
+
     public function testValidation()
     {
         $action = new IndexAction('test', new Controller('test', \Yii::$app), [


### PR DESCRIPTION
If you try to use the IndexAction with the page parameter specified it causes a 500.

I resolved this by properly associating the page parameter in the index action.

Is there a reason to set params manually? If not then that line can be removed, along with the test.