### PR TITLE
Throw a method not supported on POST singular relation update

### DIFF
--- a/src/actions/UpdateRelationshipAction.php
+++ b/src/actions/UpdateRelationshipAction.php
@@ -9,6 +9,7 @@ use yii\data\ActiveDataProvider;
 use yii\db\BaseActiveRecord;
 use yii\web\BadRequestHttpException;
 use yii\web\NotFoundHttpException;
+use yii\web\MethodNotAllowedHttpException;
 use Yii;
 
 /**
@@ -32,6 +33,10 @@ class UpdateRelationshipAction extends Action
 
         if (!$related = $model->getRelation($name, false)) {
             throw new NotFoundHttpException('Relationship does not exist');
+        }
+
+        if (!$related->multiple && Yii::$app->request->isPost) {
+            throw new MethodNotAllowedHttpException();
         }
 
         if ($this->checkAccess) {


### PR DESCRIPTION
In the JSON:Api spec, to-one relationships can only be updated with PATCH requests.

This throws a method unsupported (rather than just handling the request), alternatively we could throw a 404, but I feel that's misleading as the url is correct but the method isn't.

I wasn't sure how to properly test this (normally i'd use mockery but it isn't included in the repo), any feedback on testing would be great.