### PR TITLE
fix "like" filtering

### DIFF
--- a/src/actions/IndexAction.php
+++ b/src/actions/IndexAction.php
@@ -118,7 +118,7 @@ class IndexAction extends Action
         $attributeMap = [];
         foreach ($requestParams as $attribute => $value) {
             $attributeMap[$attribute] = Inflector::camel2id(Inflector::variablize($attribute), '_');
-            if (strpos($value, ',') !== false) {
+            if (is_string($value) && strpos($value, ',') !== false) {
                 $requestParams[$attribute] = ['in' => explode(',', $value)];
             }
         }


### PR DESCRIPTION
There was an error when I try to filter with "like" condition.
Example of filtering url:
/some/path?filter[name][like]=mySearchQuery

With corresponding fix filter works.